### PR TITLE
Remove redefinition of GamepadMappingType enum 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -202,7 +202,7 @@ The following {{Gamepad}} attributes MUST exhibit the following behavioral restr
   - {{XRInputSource/gamepad}}'s {{Gamepad/connected}} attribute MUST be <code>true</code> until the {{XRInputSource}} is removed from the [=list of active XR input sources=] or the {{XRSession}} is ended.
   - If an axis reported by the {{XRInputSource/gamepad}}'s {{Gamepad/axes}} array represents an axis of a touchpad, the value MUST be <code>0</code> when the associated {{GamepadButton}}'s {{GamepadButton/touched}} is <code>false</code>.
 
-"xr-standard" Gamepad Mapping {#xr-standard-gamepad-mapping}
+<dfn export id="xr-standard-gamepad-mapping">"xr-standard" Gamepad Mapping</dfn> {#xr-standard-heading}
 -----------------------------
 
 The {{GamepadMappingType/"xr-standard"}} mapping is defined in the <a href="https://www.w3.org/TR/gamepad/#dom-gamepadmappingtype">Gamepad API</a> and reserved for use by this spec. It indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.

--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ Editor: Nell Waliczek 93109, Amazon [Microsoft until 2018] https://amazon.com/, 
 
 Abstract: This specification module describes support for accessing button, trigger, thumbstick, and touchpad data associated with virtual reality (VR) and augmented reality (AR) devices on the Web.
 
-Status Text: This WebXR Gamepads Module is designed as a module to be implemented in addition to <a href="https://www.w3.org/TR/webxr/">WebXR Device API</a>, and was originally included in WebXR Device API which was divided into core and modules. 
+Status Text: This WebXR Gamepads Module is designed as a module to be implemented in addition to <a href="https://www.w3.org/TR/webxr/">WebXR Device API</a>, and was originally included in WebXR Device API which was divided into core and modules.
 </pre>
 
 <pre class="link-defaults">
@@ -121,7 +121,7 @@ Introduction {#intro}
 
 <section class="non-normative">
 
-Hardware that enables Virtual Reality (VR) and Augmented Reality (AR) applications are now broadly available to consumers, offering an immersive computing platform with both new opportunities and challenges. The ability to interact directly with immersive hardware is critical to ensuring that the web is well equipped to operate as a first-class citizen in this environment. The WebXR Gamepads module adds interfaces and behaviors to the WebXR Device API and the Gamepads API to allow for querying the state of buttons, triggers, thumbsticks, and touchpads available as input sources on many WebXR compatible devices. 
+Hardware that enables Virtual Reality (VR) and Augmented Reality (AR) applications are now broadly available to consumers, offering an immersive computing platform with both new opportunities and challenges. The ability to interact directly with immersive hardware is critical to ensuring that the web is well equipped to operate as a first-class citizen in this environment. The WebXR Gamepads module adds interfaces and behaviors to the WebXR Device API and the Gamepads API to allow for querying the state of buttons, triggers, thumbsticks, and touchpads available as input sources on many WebXR compatible devices.
 
 </section>
 
@@ -186,7 +186,7 @@ Gamepad API Integration {#gamepad-api-integration}
 ========================
 
 {{Gamepad}} instances returned by an {{XRInputSource}}'s {{XRInputSource/gamepad}} attribute behave as described by the <a href="https://www.w3.org/TR/gamepad/">Gamepad API</a>, with several additional behavioral restrictions.
- 
+
 Navigator {#navigator-differences}
 -----------------------
 
@@ -205,17 +205,7 @@ The following {{Gamepad}} attributes MUST exhibit the following behavioral restr
 "xr-standard" Gamepad Mapping {#xr-standard-gamepad-mapping}
 -----------------------------
 
-This module extends the {{GamepadMappingType}} to describe the mapping of common XR controller devices.
-
-<pre class="idl">
-  enum GamepadMappingType {
-    "",            // Defined in the Gamepad API
-    "standard",    // Defined in the Gamepad API
-    "xr-standard",
-  };
-</pre>
-
-The <dfn enum-value for="GamepadMappingType">xr-standard</dfn> mapping indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.
+The {{GamepadMappingType/"xr-standard"}} mapping is defined in the <a href="https://www.w3.org/TR/gamepad/#dom-gamepadmappingtype">Gamepad API</a> and reserved for use by this spec. It indicates that the layout of the buttons and axes of the {{XRInputSource/gamepad}} corresponds as closely as possible to the tables below.
 
 In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/"xr-standard"}} the device MUST report a {{XRInputSource/targetRayMode}} of {{XRTargetRayMode/"tracked-pointer"}} and MUST have a non-<code>null</code> {{XRInputSource/gripSpace}}. It MUST have at least one <dfn>primary trigger</dfn>, separate from any touchpads or thumbsticks. The [=primary trigger=] MUST trigger the [=primary action=] for the input source. The device MAY have a <dfn>primary squeeze button</dfn>, which, if present, MUST trigger the [=primary squeeze action=] for the input source. If a device does not meet the requirements for the {{GamepadMappingType/"xr-standard"}} mapping it may still expose a {{XRInputSource/gamepad}} with a {{Gamepad/mapping}} of <code>""</code> (empty string). The {{GamepadMappingType/"xr-standard"}} mapping MUST only be used by {{Gamepad}} instances reported by an {{XRInputSource}}.
 
@@ -300,7 +290,7 @@ The WebXR Device API provides powerful new features which bring with them severa
 Fingerprinting {#fingerprinting-security}
 --------------
 
-Given that the API describes hardware available to the user and its capabilities it will inevitably provide additional surface area for fingerprinting. While it's impossible to completely avoid this, user agents should take steps to mitigate the issue. As defined in the WebXR Device API, {{XRInputSource}}s are only reported after an {{XRSession}} has been created, which requires additional protections when [=sensitive information=] will be exposed. In addition, this module requires {{XRInputSource}}'s {{XRInputSource/gamepad}}.{{Gamepad/id}} to not report a string identifiers.  
+Given that the API describes hardware available to the user and its capabilities it will inevitably provide additional surface area for fingerprinting. While it's impossible to completely avoid this, user agents should take steps to mitigate the issue. As defined in the WebXR Device API, {{XRInputSource}}s are only reported after an {{XRSession}} has been created, which requires additional protections when [=sensitive information=] will be exposed. In addition, this module requires {{XRInputSource}}'s {{XRInputSource/gamepad}}.{{Gamepad/id}} to not report a string identifiers.
 
 Acknowledgements {#ack}
 ================


### PR DESCRIPTION
Closes #35

This should not land until https://github.com/w3c/gamepad/pull/146 is merged. It will remove this spec's redefinition of the enum, which was causing problems for WebIDL tooling, and point to the Gamepad API's definition as the authoritative one.