### PR TITLE
Add spec text specifying that reserved buttons are not exposed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,7 @@ spec:webxr-1;
     type: dfn; text: primary action
     type: dfn; text: xr animation frame
     type: dfn; text: primary squeeze action
+    type: dfn; text: trusted ui
 </pre>
 
 <pre class="anchors">
@@ -101,19 +102,19 @@ spec: Gamepad; urlPrefix: https://www.w3.org/TR/gamepad/#
   .tg th {
     border-style: solid;
     border-width: 1px;
-    background: #90b8de;
+    background: var(--def-bg);
     color: #fff;
     font-family: sans-serif;
     font-weight: bold;
-    border-color: grey;
+    border-color: var(--def-border);
   }
   .tg td {
     padding: 4px 5px;
-    background-color: rgb(221, 238, 255);
+    background-color: var(--def-bg);
     font-family: monospace;
     border-style: solid;
     border-width: 1px;
-    border-color: grey;
+    border-color: var(--def-border);
     overflow: hidden;
     word-break: normal;
   }
@@ -278,7 +279,18 @@ In order to report a {{Gamepad/mapping}} of {{GamepadMappingType/"xr-standard"}}
 
 Devices that lack one of the optional inputs listed in the tables above MUST preserve their place in the {{Gamepad/buttons}} or {{Gamepad/axes}} array, reporting a [=placeholder button=] or [=placeholder axis=], respectively. A <dfn>placeholder button</dfn> MUST report <code>0</code> for {{GamepadButton/value}}, <code>false</code> for {{GamepadButton/pressed}}, and <code>false</code> for {{GamepadButton/touched}}. A <dfn>placeholder axis</dfn> MUST report <code>0</code>. [=Placeholder buttons=] and [=placeholder axis|axes=] MUST be omitted if they are the last element in the array or all following elements are also [=placeholder buttons=] or [=placeholder axis|axes=].
 
-Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) MUST be grouped and, if applicable, MUST appear in X, Y, Z order. Buttons reserved by the UA or platform MUST NOT be exposed.
+Additional buttons or axes may be exposed after these reserved indices, and SHOULD appear in order of decreasing importance. Related axes (such as both axes of a thumbstick) MUST be grouped and, if applicable, MUST appear in X, Y, Z order.
+
+UA/Platform reserved buttons {#reserved-buttons}
+-----------------------------
+User Agents SHOULD reserve at least one physical button, when possible, for performing unspoofable actions as part of a [=trusted UI=]. For example, the User Agent could designate the "menu" or "app" button present on many controllers as a dedicated button for exiting immersive presentation.
+
+Additionally, many XR platforms also reserve a button for platform specific actions, such as returning to a home environment.
+
+Buttons reserved by the UA or platform MUST NOT be exposed on the {{Gamepad}}. Additionally, User Agents SHOULD make an effort to coordinate which buttons are reserved for a given XR platform. The <a href="https://github.com/immersive-web/webxr-input-profiles/tree/master/packages/registry">WebXR Input Profiles Registry</a> is the recommended location for coordinating button reservations.
+
+Example Mappings {#example-mappings}
+-----------------------------
 
 <section class="note">
 This diagram demonstrates how two example controllers would be exposed with the {{GamepadMappingType/"xr-standard"}} mapping. Images are not intended to represent any particular device and are used for reference purposes only. <img src="images/xr-standard-mapping.svg" width="2100" height="2530" style="width: 750px; height: auto;" alt="Simple 'xr-standard' controller and Advanced 'xr-standard' controller">


### PR DESCRIPTION
Fixes #37.

Also pulls in a fix to the table coloring in dark mode that @Manishearth added to https://github.com/immersive-web/webxr-hand-input previously.