### PR TITLE
Address contradiction on whether XRInputSource gamepads are exposed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -190,14 +190,12 @@ Gamepad API Integration {#gamepad-api-integration}
 
 {{Gamepad}} instances returned by an {{XRInputSource}}'s {{XRInputSource/gamepad}} attribute behave as described by the <a href="https://www.w3.org/TR/gamepad/">Gamepad API</a>, with several additional behavioral restrictions.
 
-An {{XRInputSource}}'s associated {{Gamepad}} MAY be exposed via {{navigator.getGamepads()}}, even if there is no active XR session by user agent choice. This allows XR devices to be used as "regular" gamepads if the user agent wishes to allow this.
-
 Note: Hand tracking {{XRInputSource}}s as described in [[WEBXR-HAND-INPUT-1]] may contain a {{Gamepad}} if the user agent wishes to allow hand-based input sources to be used with gamepad-based content.
 
 Navigator {#navigator-differences}
 -----------------------
 
-The <a href="https://www.w3.org/TR/gamepad/">Gamepad API</a> states a snapshot of {{Gamepad}} data can be retrieved by calling the {{navigator.getGamepads()}} function. However, {{Gamepad}} instances returned by an {{XRInputSource}}'s {{XRInputSource/gamepad}} attribute MUST NOT be included in the array returned by {{navigator.getGamepads()}}.
+An {{XRInputSource}}'s associated {{Gamepad}} MAY be exposed via {{navigator.getGamepads()}}, even if there is no active XR session by user agent choice. This allows XR devices to be used as "regular" gamepads if the user agent wishes to allow this.
 
 Gamepad {#gamepad-differences}
 ------------------------


### PR DESCRIPTION
While looking over this spec in preparation for eventually updating Servo's WebXR implementation, I noticed a very clear contradiction between the intro text to the Gamepad API integration and the Navigator section. The intro text states that user agents MAY expose XRInputSource gamepads via `navigator.getGamepads()`, but the following section states that they MUST NOT be exposed. Looking at the git blame, it seems like the intro text change was more recent, so I think it makes sense to treat that as the ground truth.