### PR TITLE
fixed html syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -180,7 +180,6 @@ To <dfn for=XRFrame>apply gamepad frame updates</dfn> for an {{XRFrame}} |frame|
  1. For each {{XRInputSource}} with a {{XRInputSource/gamepad}} |gamepad| associated with |frame|'s {{XRFrame/session}}, perform the following steps:
     1. Update |gamepad| to reflect the gamepad data at |frame|'s [=XRFrame/time=].
 
-</div>
 
 NOTE: This means that the {{XRInputSource/gamepad}} object is "live", and any internal state is to be updated in-place every frame. Furthermore, it doesn't work to save a reference to an {{XRInputSource}}'s {{gamepad}} on one frame and compare it to the same {{XRInputSource}}'s {{gamepad}} from a subsequent frame to test for state changes, because they will be the same object. Therefore developers that wish to compare input state from frame to frame should cache the state in question.
 
@@ -336,4 +335,3 @@ The following individuals have contributed to the design of the WebXR Device API
 
 And a special thanks to <a href="mailto:vladv@unity3d.com">Vladimir Vukicevic</a> (<a href="https://unity3d.com/">Unity</a>) for kick-starting this whole adventure!
 
-</section>


### PR DESCRIPTION
as title.

could need to check first `</div>`, but it's almost at top of section, so we may not place any div (for id?) here...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/webxr-gamepads-module/pull/63.html" title="Last updated on Jul 4, 2025, 5:20 AM UTC (a1cb602)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-gamepads-module/63/b33e2a8...himorin:a1cb602.html" title="Last updated on Jul 4, 2025, 5:20 AM UTC (a1cb602)">Diff</a>